### PR TITLE
fix(security): remove disable-web-security due to issues with Zuora

### DIFF
--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -127,7 +127,6 @@ export class Plugin {
         ...args,
         '--no-sandbox',
         '--disable-background-networking',
-        '--disable-web-security',
         '--reduce-security-for-testing',
         '--allow-insecure-localhost',
         '--ignore-certificate-errors'


### PR DESCRIPTION
having problem when use this with Zuora's HMAC protocol
https://www.zuora.com/developer/api-reference/#tag/HMAC-Signatures

I found if I delete that option, everything would still work. Curious why that was added to begin with.