### PR TITLE
make fileName and outDir optional on SaveOptions

### DIFF
--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -10,8 +10,8 @@ import { Entry, Har } from 'har-format';
 import { join } from 'path';
 
 export interface SaveOptions {
-  fileName: string;
-  outDir: string;
+  fileName?: string;
+  outDir?: string;
 }
 
 export interface RecordOptions {

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -10,8 +10,8 @@ import { Entry, Har } from 'har-format';
 import { join } from 'path';
 
 export interface SaveOptions {
-  fileName?: string;
-  outDir?: string;
+  fileName: string;
+  outDir: string;
 }
 
 export interface RecordOptions {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -25,7 +25,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'saveHar',
-  (options?: SaveOptions): Cypress.Chainable => {
+  (options?: Partial<SaveOptions>): Cypress.Chainable => {
     const fallbackFileName: string = Cypress.spec.name;
     const outDir: string = Cypress.env('hars_folders') ?? './';
 


### PR DESCRIPTION
According to the documentation of this library it implies that you can specify `fileName` and `outDir` independently of each other. However this type is written such that you need to specify both even when you may only want to override one. (ie: only `outDir` and not `fileName`).

I've made both of the properties on the SaveOptions type to be optional to solve this. If nothing is specified, then the default behavior occurs. 