### PR TITLE
Allow user to filter pathnames from the recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ You can set `content` flag to `false` to skip loading `content` fields in the HA
 cy.recordHar({ content: false });
 ```
 
+To exclude some requests, you can specify a list of paths to be excluded using `excludePaths`.
+
+```js
+cy.recordHar({ excludePaths: ['^/login', 'logout$'] });
+```
+
 
 ### saveHar
 
@@ -115,6 +121,7 @@ beforeEach(() => {
     cy.recordHar();
   }
 });
+
 afterEach(() => {
   const { state } = this.currentTest;
   const isInteractive = Cypress.config('isInteractive');

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -107,19 +107,8 @@ export class Plugin {
     );
 
     await networkObservable.subscribe(
-      async (request: NetworkRequest): Promise<number> => {
-        const requestPath = request.parsedURL.path;
-        const isRequestExcluded = options.excludePaths?.some(
-          (excludedPath: string): boolean =>
-            requestPath?.startsWith(excludedPath)
-        );
-
-        if (isRequestExcluded) {
-          return this.entries.length;
-        }
-
-        return this.entries.push(await new EntryBuilder(request).build());
-      }
+      async (request: NetworkRequest): Promise<number> =>
+        this.entries.push(await new EntryBuilder(request).build())
     );
   }
 

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -16,6 +16,7 @@ export interface SaveOptions {
 
 export interface RecordOptions {
   content: boolean;
+  excludePaths: string[];
 }
 
 export class Plugin {
@@ -106,8 +107,19 @@ export class Plugin {
     );
 
     await networkObservable.subscribe(
-      async (request: NetworkRequest): Promise<number> =>
-        this.entries.push(await new EntryBuilder(request).build())
+      async (request: NetworkRequest): Promise<number> => {
+        const requestPath = request.parsedURL.path;
+        const isRequestExcluded = options.excludePaths?.some(
+          (excludedPath: string): boolean =>
+            requestPath?.startsWith(excludedPath)
+        );
+
+        if (isRequestExcluded) {
+          return this.entries.length;
+        }
+
+        return this.entries.push(await new EntryBuilder(request).build());
+      }
     );
   }
 

--- a/src/network/NetworkObserver.ts
+++ b/src/network/NetworkObserver.ts
@@ -424,7 +424,10 @@ export class NetworkObserver {
 
     this._entries.delete(networkRequest.requestId);
     this.getExtraInfoBuilder(networkRequest.requestId).finished();
-    this.destination(networkRequest);
+
+    if (!this.excludeRequest(networkRequest)) {
+      this.destination(networkRequest);
+    }
   }
 
   private startRequest(networkRequest: NetworkRequest): void {
@@ -535,6 +538,14 @@ export class NetworkObserver {
         return acc;
       },
       []
+    );
+  }
+
+  private excludeRequest(request: NetworkRequest): boolean {
+    const { path = '/' } = request.parsedURL;
+
+    return !!this.options.excludePaths?.some((excludedPath: string): boolean =>
+      new RegExp(excludedPath).test(path)
     );
   }
 


### PR DESCRIPTION
These changes add a new attribute `excludePaths` to the available Record
Options.

Consumers may provide a set of pathnames which will be used
to filter network entries from the recorded HAR file.
