### PR TITLE
Add support for recording external network requests

### DIFF
--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -62,6 +62,10 @@ export class Plugin {
     return null;
   }
 
+  public async recordNetworkRequest(request: NetworkRequest): Promise<number> {
+    return this.entries.push(await new EntryBuilder(request).build());
+  }
+
   public async saveHar(options: SaveOptions): Promise<void> {
     const filePath: string = join(options.outDir, options.fileName);
 
@@ -111,7 +115,7 @@ export class Plugin {
           return this.entries.length;
         }
 
-        return this.entries.push(await new EntryBuilder(request).build());
+        return await this.recordNetworkRequest(request);
       }
     );
   }

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -16,6 +16,7 @@ export interface SaveOptions {
 
 export interface RecordOptions {
   content: boolean;
+  excludePaths: string[];
 }
 
 export class Plugin {
@@ -99,8 +100,19 @@ export class Plugin {
     );
 
     await networkObservable.subscribe(
-      async (request: NetworkRequest): Promise<number> =>
-        this.entries.push(await new EntryBuilder(request).build())
+      async (request: NetworkRequest): Promise<number> => {
+        const requestPath = request.parsedURL.path;
+        const isRequestExcluded = options.excludePaths?.some(
+          (excludedPath: string): boolean =>
+            requestPath?.startsWith(excludedPath)
+        );
+
+        if (isRequestExcluded) {
+          return this.entries.length;
+        }
+
+        return this.entries.push(await new EntryBuilder(request).build());
+      }
     );
   }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,5 @@
 import { RecordOptions, SaveOptions } from './Plugin';
+import { NetworkRequest } from './network';
 
 const filename = (path: string): string | undefined => {
   const startIndex: number =
@@ -21,6 +22,12 @@ Cypress.Commands.add(
   'recordHar',
   (options?: RecordOptions): Cypress.Chainable =>
     cy.task('recordHar', Object.assign({ content: true }, options))
+);
+
+Cypress.Commands.add(
+  'recordNetworkRequest',
+  (request: NetworkRequest): Cypress.Chainable =>
+    cy.task('recordNetworkRequest', request)
 );
 
 Cypress.Commands.add(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, RecordOptions, SaveOptions } from './Plugin';
 import { FileManager, Logger } from './utils';
+import { NetworkRequest } from './network';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -8,6 +9,8 @@ declare global {
       saveHar(options?: Partial<SaveOptions>): Chainable<Subject>;
 
       recordHar(options?: RecordOptions): Chainable<Subject>;
+
+      recordNetworkRequest(request: NetworkRequest): Chainable<Subject>;
     }
   }
 }
@@ -16,6 +19,8 @@ interface CypressTasks {
   saveHar(options: SaveOptions): Promise<void>;
 
   recordHar(options: RecordOptions): Promise<void>;
+
+  recordNetworkRequest(request: NetworkRequest): Promise<number>;
 }
 
 type CypressCallback = (event: 'task', arg?: CypressTasks) => void;
@@ -26,7 +31,9 @@ export const install = (on: CypressCallback): void => {
   on('task', {
     saveHar: (options: SaveOptions): Promise<void> => plugin.saveHar(options),
     recordHar: (options: RecordOptions): Promise<void> =>
-      plugin.recordHar(options)
+      plugin.recordHar(options),
+    recordNetworkRequest: (request: NetworkRequest): Promise<number> =>
+      plugin.recordNetworkRequest(request)
   });
 };
 


### PR DESCRIPTION
These changes add an additional Cypress command `recordNetworkRequest`
which can be used to manually amend a network request onto an
on-going recording.

This is useful for situations where a Cypress task is used to make a
network request. Previously this request could not be saved in the
recording.

---

Example usage in a Cypress command:

```
        cy.intercept('GET', 'mysite.com/api/users', (req) => {
          cy.recordNetworkRequest(req);
        })
        cy.request({
          method: 'GET',
          url: mysite.com/api/users,
          headers: options.headers,
        })
```
 
