### PR TITLE
fix(network): handle case where `requestContentType` is undefined

### DIFF
--- a/src/network/NetworkRequest.ts
+++ b/src/network/NetworkRequest.ts
@@ -673,7 +673,7 @@ export class NetworkRequest {
       return this.parseParameters(formUrlencoded);
     }
 
-    const multipartDetails: RegExpMatchArray = this.requestContentType.match(
+    const multipartDetails: RegExpMatchArray = this.requestContentType?.match(
       /^multipart\/form-data\s*;\s*boundary\s*=\s*(\S+)\s*$/
     );
 


### PR DESCRIPTION
This fixes an issue where the plugin crashes if a request does not have a Content-Type header.