### PR TITLE
feat(network): allow to filter hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ You can set `content` flag to `false` to skip loading `content` fields in the HA
 cy.recordHar({ content: false });
 ```
 
-To include only requests on specific hosts, you can specify a list of hosts using `hostPatterns`.
+To include only requests on specific hosts, you can specify a list of hosts using `includeHosts`.
 
 ```js
-cy.recordHar({ hostPatterns: [ '.*.execute-api.eu-west-1.amazonaws.com'] });
+cy.recordHar({ includeHosts: [ '.*.execute-api.eu-west-1.amazonaws.com'] });
 ```
 
 To exclude some requests, you can specify a list of paths to be excluded using `excludePaths`.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ You can set `content` flag to `false` to skip loading `content` fields in the HA
 cy.recordHar({ content: false });
 ```
 
+To include only requests on specific hosts, you can specify a list of hosts using `hostPatterns`.
+
+```js
+cy.recordHar({ hostPatterns: [ '.*.execute-api.eu-west-1.amazonaws.com'] });
+```
+
 To exclude some requests, you can specify a list of paths to be excluded using `excludePaths`.
 
 ```js

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -17,7 +17,7 @@ export interface SaveOptions {
 export interface RecordOptions {
   content: boolean;
   excludePaths: string[];
-  hostPatterns: string[];
+  includeHosts: string[];
 }
 
 export class Plugin {

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -17,6 +17,7 @@ export interface SaveOptions {
 export interface RecordOptions {
   content: boolean;
   excludePaths: string[];
+  hostPatterns: string[];
 }
 
 export class Plugin {

--- a/src/network/NetworkObserver.ts
+++ b/src/network/NetworkObserver.ts
@@ -543,10 +543,10 @@ export class NetworkObserver {
 
   private excludeRequest(request: NetworkRequest): boolean {
     const { host, path = '/' } = request.parsedURL;
-    const { hostPatterns, excludePaths } = this.options;
-    if (hostPatterns && hostPatterns.length > 0) {
+    const { includeHosts, excludePaths } = this.options;
+    if (includeHosts && includeHosts.length > 0) {
       if (
-        !hostPatterns.some((hostPattern: string): boolean =>
+        !includeHosts.some((hostPattern: string): boolean =>
           new RegExp(hostPattern).test(host)
         )
       ) {

--- a/src/network/NetworkObserver.ts
+++ b/src/network/NetworkObserver.ts
@@ -544,7 +544,7 @@ export class NetworkObserver {
   private excludeRequest(request: NetworkRequest): boolean {
     const { host, path = '/' } = request.parsedURL;
     const { includeHosts, excludePaths } = this.options;
-    if (includeHosts && includeHosts.length > 0) {
+    if (includeHosts?.length > 0) {
       if (
         !includeHosts.some((hostPattern: string): boolean =>
           new RegExp(hostPattern).test(host)

--- a/src/network/NetworkObserver.ts
+++ b/src/network/NetworkObserver.ts
@@ -542,9 +542,19 @@ export class NetworkObserver {
   }
 
   private excludeRequest(request: NetworkRequest): boolean {
-    const { path = '/' } = request.parsedURL;
+    const { host, path = '/' } = request.parsedURL;
+    const { hostPatterns, excludePaths } = this.options;
+    if (hostPatterns && hostPatterns.length > 0) {
+      if (
+        !hostPatterns.some((hostPattern: string): boolean =>
+          new RegExp(hostPattern).test(host)
+        )
+      ) {
+        return true;
+      }
+    }
 
-    return !!this.options.excludePaths?.some((excludedPath: string): boolean =>
+    return !!excludePaths?.some((excludedPath: string): boolean =>
       new RegExp(excludedPath).test(path)
     );
   }


### PR DESCRIPTION
Extend recording options by adding `includeHosts` field to include only requests on specific hosts.
