### PR TITLE
fix(plugin): prevent NPE on writable stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,10 @@ npm i --save-dev @neuralegion/cypress-har-generator
 Next, go to the cypress's directory and put this code is in your `cypress/plugins/index.js` file:
 
 ```js
-const {
-  install,
-  ensureBrowserFlags
-} = require('@neuralegion/cypress-har-generator');
+const { install } = require('@neuralegion/cypress-har-generator');
 
-module.exports = (on, config) => {
-  install(on, config);
-
-  on('before:browser:launch', (browser = {}, launchOptions) => {
-    ensureBrowserFlags(browser, launchOptions);
-    return launchOptions;
-  });
+module.exports = on => {
+  install(on);
 };
 ```
 
@@ -38,23 +30,14 @@ module.exports = (on, config) => {
 >
 > ```js
 > const { defineConfig } = require('cypress');
-> const {
->   install,
->   ensureBrowserFlags
-> } = require('@neuralegion/cypress-har-generator');
+> const { install } = require('@neuralegion/cypress-har-generator');
 >
 > module.exports = defineConfig({
 >   // setupNodeEvents can be defined in either
 >   // the e2e or component configuration
 >   e2e: {
->     setupNodeEvents(on, config) {
->       install(on, config);
->
->       on('before:browser:launch', (browser = {}, launchOptions) => {
->         ensureBrowserFlags(browser, launchOptions);
->
->         return launchOptions;
->       });
+>     setupNodeEvents(on) {
+>       install(on);
 >     }
 >   }
 > });

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -112,10 +112,15 @@ export class Plugin {
     await this.networkObservable?.unsubscribe();
     delete this.networkObservable;
 
+    if (this.buffer) {
+      this.buffer.end();
+    }
+
     if (this.tmpPath) {
       await this.fileManager.removeFile(this.tmpPath);
-      delete this.buffer;
     }
+
+    delete this.buffer;
   }
 
   private async buildHar(): Promise<string | undefined> {
@@ -146,7 +151,10 @@ export class Plugin {
     return this.networkObservable.subscribe(async (request: NetworkRequest) => {
       const entry = await new EntryBuilder(request).build();
       const entryStr = JSON.stringify(entry);
-      this.buffer.write(`${entryStr}${EOL}`);
+      // @ts-expect-error type mismatch
+      if (this.buffer && !this.buffer.closed) {
+        this.buffer.write(`${entryStr}${EOL}`);
+      }
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,34 @@ export const install = (on: Cypress.PluginEvents): void => {
     recordHar: (options: RecordOptions): Promise<void> =>
       plugin.recordHar(options)
   });
+
+  on(
+    'before:browser:launch',
+    (
+      browser: Cypress.Browser | null,
+      launchOptions: Cypress.BrowserLaunchOptions
+    ) => {
+      ensureBrowserFlags((browser ?? {}) as Cypress.Browser, launchOptions);
+
+      return launchOptions;
+    }
+  );
 };
 
+/**
+ * Function has been deprecated. Use {@link install} instead as follows:
+ * ```diff
+ * setupNodeEvents(on) {
+ *   install(on);
+ * -  // bind to the event we care about
+ * -  on('before:browser:launch', (browser = {}, launchOptions) => {
+ * -    ensureBrowserFlags(browser, launchOptions);
+ * -    return launchOptions;
+ * -  });
+ * }
+ * ```
+ * In case of any issues please refer to {@link https://github.com/cypress-io/cypress/issues/5240}
+ */
 export const ensureBrowserFlags = (
   browser: Cypress.Browser,
   launchOptions: Cypress.BrowserLaunchOptions


### PR DESCRIPTION
The `ensureBrowserFlags` function has been deprecated. Use the `install` function instead as follows:

```diff
setupNodeEvents(on) {
  install(on);
-
-  on('before:browser:launch', (browser = {}, launchOptions) => {
-    ensureBrowserFlags(browser, launchOptions);
-    return launchOptions;
-  });
}
```
In case of any issues please refer to Cypress-io/cypress#5240

closes #100