### PR TITLE
feat(network): allow to excluding requests based on their status

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ cy.recordHar({ includeMimes: ['application/json'] });
 
 This will record only requests with a MIME type of `application/json`.
 
+To exclude requests based on their status code, you can use the `minStatusCodeToInclude` field.
+
+For example, to only include requests that have a status code of 400 or greater, you can pass the `minStatusCodeToInclude` option as follows:
+
+```js
+cy.recordHar({ minStatusCodeToInclude: 400 });
+```
+
 ### saveHar
 
 Stops recording and saves all requests that have occurred since `recordHar` was run to a HAR file. By default, the file is saved to the root of the project with a file name that includes the current spec's name (e.g. `{specName}.har`).

--- a/src/network/NetworkObserverOptions.ts
+++ b/src/network/NetworkObserverOptions.ts
@@ -3,4 +3,5 @@ export interface NetworkObserverOptions {
   excludePaths?: string[];
   includeHosts?: string[];
   includeMimes?: string[];
+  minStatusCodeToInclude?: number;
 }

--- a/src/network/filters/CompositeFilter.ts
+++ b/src/network/filters/CompositeFilter.ts
@@ -3,13 +3,15 @@ import { NetworkRequest } from '../NetworkRequest';
 import { HostFilter } from './HostFilter';
 import { PathFilter } from './PathFilter';
 import { MimeFilter } from './MimeFilter';
+import { StatusCodeFilter } from './StatusCodeFilter';
 
 export class CompositeFilter implements RequestFilter {
   constructor(
     private readonly children: RequestFilter[] = [
       new HostFilter(),
       new PathFilter(),
-      new MimeFilter()
+      new MimeFilter(),
+      new StatusCodeFilter()
     ]
   ) {}
 

--- a/src/network/filters/StatusCodeFilter.spec.ts
+++ b/src/network/filters/StatusCodeFilter.spec.ts
@@ -1,0 +1,78 @@
+import { StatusCodeFilter } from './StatusCodeFilter';
+import { RequestFilterOptions } from './RequestFilter';
+import { NetworkRequest } from '../NetworkRequest';
+import { describe, beforeEach, it, expect } from '@jest/globals';
+import { instance, mock, reset, when } from 'ts-mockito';
+
+describe('StatusCodeFilter', () => {
+  const networkRequestMock = mock<NetworkRequest>();
+
+  let sut!: StatusCodeFilter;
+
+  beforeEach(() => {
+    sut = new StatusCodeFilter();
+  });
+
+  afterEach(() => reset(networkRequestMock));
+
+  describe('wouldApply', () => {
+    it.each([
+      {},
+      { minStatusCodeToInclude: undefined },
+      { minStatusCodeToInclude: null },
+      { minStatusCodeToInclude: 'test' },
+      { minStatusCodeToInclude: NaN }
+    ])(
+      'should return false when the filter is not applicable (options: %j)',
+      options => {
+        // act
+        const result = sut.wouldApply(
+          options as unknown as RequestFilterOptions
+        );
+        // assert
+        expect(result).toBe(false);
+      }
+    );
+
+    it.each([
+      { minStatusCodeToInclude: 1 },
+      { minStatusCodeToInclude: -1 },
+      { minStatusCodeToInclude: 1.1 },
+      { minStatusCodeToInclude: '1' }
+    ])(
+      'should return true when the filter is applicable (options: %j)',
+      options => {
+        // act
+        const result = sut.wouldApply(
+          options as unknown as RequestFilterOptions
+        );
+        // assert
+        expect(result).toBe(true);
+      }
+    );
+  });
+
+  describe('apply', () => {
+    it('should return true if the request status code equals or is greater than the threshold', () => {
+      // arrange
+      const statusCode = 200;
+      when(networkRequestMock.statusCode).thenReturn(statusCode);
+      const options = { minStatusCodeToInclude: statusCode };
+      // act
+      const result = sut.apply(instance(networkRequestMock), options);
+      // assert
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the request status code is less than the threshold', () => {
+      // arrange
+      const statusCode = 101;
+      when(networkRequestMock.statusCode).thenReturn(statusCode);
+      const options = { minStatusCodeToInclude: 200 };
+      // act
+      const result = sut.apply(instance(networkRequestMock), options);
+      // assert
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/network/filters/StatusCodeFilter.ts
+++ b/src/network/filters/StatusCodeFilter.ts
@@ -1,0 +1,25 @@
+import { RequestFilter, RequestFilterOptions } from './RequestFilter';
+import { NetworkRequest } from '../NetworkRequest';
+
+export class StatusCodeFilter implements RequestFilter {
+  public apply(
+    request: NetworkRequest,
+    { minStatusCodeToInclude = 0 }: RequestFilterOptions
+  ): boolean {
+    const threshold = this.normalizeThreshold(minStatusCodeToInclude);
+
+    return request.statusCode >= threshold;
+  }
+
+  public wouldApply(options: RequestFilterOptions): boolean {
+    const threshold = this.normalizeThreshold(options.minStatusCodeToInclude);
+
+    return typeof threshold === 'number';
+  }
+
+  private normalizeThreshold(value: unknown): number | undefined {
+    return !isNaN(+value) && value !== null
+      ? Math.round(Math.abs(+value))
+      : undefined;
+  }
+}


### PR DESCRIPTION
To exclude requests based on their status code, you can use the `minStatusCodeToInclude` field.

For example, to only include requests that have a status code of 400 or greater, you can pass the `minStatusCodeToInclude` option as follows:

```js
cy.recordHar({ minStatusCodeToInclude: 400 });
```

closes #65