### PR TITLE
feat(network): filter blob network requests out from the HAR file

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ For example, to only include requests that have a status code of 400 or greater,
 cy.recordHar({ minStatusCodeToInclude: 400 });
 ```
 
+By default, when you use cy.recordHar command, it will include the blob requests in the recorded HAR file. However, those requests only make sense when they are used on the same page they were created. To exclude the blob requests from the recorded HAR file, set the `includeBlobs` to false as follows:
+
+```js
+cy.recordHar({ includeBlobs: false });
+```
+
+> ✴ As of version 6, this flag will be disabled by default.
+
 ### saveHar
 
 Stops recording and saves all requests that have occurred since `recordHar` was run to a HAR file. By default, the file is saved to the root of the project with a file name that includes the current spec's name (e.g. `{specName}.har`).

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ For example, to only include requests that have a status code of 400 or greater,
 cy.recordHar({ minStatusCodeToInclude: 400 });
 ```
 
-By default, when you use cy.recordHar command, it will include the blob requests in the recorded HAR file. However, those requests only make sense when they are used on the same page they were created. To exclude the blob requests from the recorded HAR file, set the `includeBlobs` to false as follows:
+By default, when you use `recordHar` command, it will include the blob requests in the recorded HAR file. However, those requests only make sense when they are used on the same page they were created. To exclude the blob requests from the recorded HAR file, set the `includeBlobs` to false as follows:
 
 ```js
 cy.recordHar({ includeBlobs: false });

--- a/src/network/DefaultObserverFactory.ts
+++ b/src/network/DefaultObserverFactory.ts
@@ -5,7 +5,7 @@ import { Connection } from '../cdp';
 import { NetworkObserverOptions } from './NetworkObserverOptions';
 import { Observer } from './Observer';
 import { NetworkRequest } from './NetworkRequest';
-import { CompositeFilter } from './filters/CompositeFilter';
+import { CompositeFilter } from './filters';
 
 export class DefaultObserverFactory implements ObserverFactory {
   private readonly defaultRequestFilter = new CompositeFilter();

--- a/src/network/NetworkObserverOptions.ts
+++ b/src/network/NetworkObserverOptions.ts
@@ -4,4 +4,8 @@ export interface NetworkObserverOptions {
   includeHosts?: string[];
   includeMimes?: string[];
   minStatusCodeToInclude?: number;
+  /**
+   * @deprecated As of version 6, this flag will be disabled by default.
+   */
+  includeBlobs?: boolean;
 }

--- a/src/network/NetworkRequest.spec.ts
+++ b/src/network/NetworkRequest.spec.ts
@@ -70,6 +70,25 @@ describe('NetworkRequest', () => {
     });
   });
 
+  describe('isBlob', () => {
+    it('should return true if the schema starts from the blob', () => {
+      // arrange
+      const url = 'blob:http://localhost:8000/image.jpg';
+      sut.setUrl(url);
+      // act
+      const result = sut.isBlob();
+      // assert
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the schema is not the blob', () => {
+      // act
+      const result = sut.isBlob();
+      // assert
+      expect(result).toBe(false);
+    });
+  });
+
   describe('addExtraResponseInfo', () => {
     it('should set response headers', () => {
       // arrange

--- a/src/network/NetworkRequest.ts
+++ b/src/network/NetworkRequest.ts
@@ -457,6 +457,10 @@ export class NetworkRequest {
     delete this._parsedQueryParameters;
   }
 
+  public isBlob(): boolean {
+    return this._url.startsWith('blob:');
+  }
+
   public setRemoteAddress(ip: string, port: number): void {
     this._remoteAddress = `${ip}:${port}`;
   }

--- a/src/network/filters/BlobFilter.spec.ts
+++ b/src/network/filters/BlobFilter.spec.ts
@@ -42,24 +42,24 @@ describe('BlobFilter', () => {
   });
 
   describe('apply', () => {
-    it('should return true if the request is blob', () => {
+    it('should return false if the request is blob', () => {
       // arrange
       when(networkRequestMock.isBlob()).thenReturn(true);
       const options = { includeBlobs: false };
       // act
       const result = sut.apply(instance(networkRequestMock), options);
       // assert
-      expect(result).toBe(true);
+      expect(result).toBe(false);
     });
 
-    it('should return false if the request is not blob', () => {
+    it('should return true if the request is not blob', () => {
       // arrange
       when(networkRequestMock.isBlob()).thenReturn(false);
       const options = { includeBlobs: false };
       // act
       const result = sut.apply(instance(networkRequestMock), options);
       // assert
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     });
   });
 });

--- a/src/network/filters/BlobFilter.spec.ts
+++ b/src/network/filters/BlobFilter.spec.ts
@@ -1,0 +1,65 @@
+import { RequestFilterOptions } from './RequestFilter';
+import { NetworkRequest } from '../NetworkRequest';
+import { BlobFilter } from './BlobFilter';
+import { describe, beforeEach, it, expect } from '@jest/globals';
+import { instance, mock, reset, when } from 'ts-mockito';
+
+describe('BlobFilter', () => {
+  const networkRequestMock = mock<NetworkRequest>();
+
+  let sut!: BlobFilter;
+
+  beforeEach(() => {
+    sut = new BlobFilter();
+  });
+
+  afterEach(() => reset(networkRequestMock));
+
+  describe('wouldApply', () => {
+    it('should return true when the filter is applicable', () => {
+      // act
+      const result = sut.wouldApply({ includeBlobs: false });
+      // assert
+      expect(result).toBe(true);
+    });
+
+    it.each([
+      {},
+      { includeBlobs: undefined },
+      { includeBlobs: null },
+      { includeBlobs: true }
+    ])(
+      'should return false when the filter is not applicable (options: %j)',
+      options => {
+        // act
+        const result = sut.wouldApply(
+          options as unknown as RequestFilterOptions
+        );
+        // assert
+        expect(result).toBe(false);
+      }
+    );
+  });
+
+  describe('apply', () => {
+    it('should return true if the request is blob', () => {
+      // arrange
+      when(networkRequestMock.isBlob()).thenReturn(true);
+      const options = { includeBlobs: false };
+      // act
+      const result = sut.apply(instance(networkRequestMock), options);
+      // assert
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the request is not blob', () => {
+      // arrange
+      when(networkRequestMock.isBlob()).thenReturn(false);
+      const options = { includeBlobs: false };
+      // act
+      const result = sut.apply(instance(networkRequestMock), options);
+      // assert
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/network/filters/BlobFilter.ts
+++ b/src/network/filters/BlobFilter.ts
@@ -1,0 +1,12 @@
+import { RequestFilter, RequestFilterOptions } from './RequestFilter';
+import { NetworkRequest } from '../NetworkRequest';
+
+export class BlobFilter implements RequestFilter {
+  public apply(request: NetworkRequest, _: RequestFilterOptions): boolean {
+    return !request.isBlob();
+  }
+
+  public wouldApply({ includeBlobs }: RequestFilterOptions): boolean {
+    return !(includeBlobs ?? true);
+  }
+}

--- a/src/network/filters/CompositeFilter.ts
+++ b/src/network/filters/CompositeFilter.ts
@@ -4,6 +4,7 @@ import { HostFilter } from './HostFilter';
 import { PathFilter } from './PathFilter';
 import { MimeFilter } from './MimeFilter';
 import { StatusCodeFilter } from './StatusCodeFilter';
+import { BlobFilter } from './BlobFilter';
 
 export class CompositeFilter implements RequestFilter {
   constructor(
@@ -11,7 +12,8 @@ export class CompositeFilter implements RequestFilter {
       new HostFilter(),
       new PathFilter(),
       new MimeFilter(),
-      new StatusCodeFilter()
+      new StatusCodeFilter(),
+      new BlobFilter()
     ]
   ) {}
 

--- a/src/network/filters/index.ts
+++ b/src/network/filters/index.ts
@@ -2,3 +2,6 @@ export * from './HostFilter';
 export * from './MimeFilter';
 export * from './PathFilter';
 export * from './RequestFilter';
+export * from './BlobFilter';
+export * from './CompositeFilter';
+export * from './StatusCodeFilter';


### PR DESCRIPTION
By default, when you use `recordHar` command, it will include the blob requests in the recorded HAR file. However, those requests only make sense when they are used on the same page they were created. To exclude the blob requests from the recorded HAR file, set the `includeBlobs` to false as follows:

```js
cy.recordHar({ includeBlobs: false });
```

> ✴ As of version 6, this flag will be disabled by default.

closes #141