### PR TITLE
feat(plugin):  wait for all requests before saving the HAR file

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ You can customize a destination folder overriding any previous settings:
 cy.saveHar({ outDir: './hars' });
 ```
 
+You can also pass the `waitForIdle` option to wait for all pending requests to complete before saving the HAR file:
+
+```js
+cy.saveHar({ waitForIdle: true });
+```
+
+This option is false by default. When set to true, the plugin will monitor the count of pending requests and wait for it to reach zero before proceeding with saving the HAR file. This ensures that all responses have been received and the data in the file is complete and accurate.
+
 ### disposeOfHar
 
 Stops the ongoing recording of network requests and disposes of the recorded logs, which will be not saved to a HAR file.

--- a/src/network/NetworkIdleMonitor.spec.ts
+++ b/src/network/NetworkIdleMonitor.spec.ts
@@ -1,0 +1,73 @@
+import { Observer } from './Observer';
+import { NetworkRequest } from './NetworkRequest';
+import { NetworkIdleMonitor } from './NetworkIdleMonitor';
+import {
+  jest,
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  expect
+} from '@jest/globals';
+import { instance, mock, reset, when } from 'ts-mockito';
+
+const findArg = <R>(
+  args: [unknown, unknown],
+  expected: 'function' | 'number'
+): R => (typeof args[0] === expected ? args[0] : args[1]) as R;
+
+const useFakeTimers = () => {
+  jest.useFakeTimers();
+
+  const mockedImplementation = jest
+    .spyOn(global, 'setTimeout')
+    .getMockImplementation();
+
+  jest
+    .spyOn(global, 'setTimeout')
+    .mockImplementation((...args: [unknown, unknown]) => {
+      // ADHOC: depending on implementation (promisify vs raw), the method signature will be different
+      const callback = findArg<(..._: unknown[]) => void>(args, 'function');
+      const ms = findArg<number>(args, 'number');
+      const timer = mockedImplementation?.(callback, ms);
+
+      jest.runAllTimers();
+
+      return timer;
+    });
+};
+
+describe('NetworkIdleMonitor', () => {
+  const observer = mock<Observer<NetworkRequest>>();
+  let sut!: NetworkIdleMonitor;
+
+  beforeEach(() => {
+    useFakeTimers();
+    sut = new NetworkIdleMonitor(instance(observer));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    reset(observer);
+  });
+
+  describe('waitForIdle', () => {
+    it('should return immediately when network is already idle', async () => {
+      // arrange
+      when(observer.empty).thenReturn(true);
+      // act
+      await sut.waitForIdle(1000);
+      // assert
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+    });
+
+    it('should wait for the specified idle time when network is not idle', async () => {
+      // arrange
+      when(observer.empty).thenReturn(false, true);
+      // act
+      await sut.waitForIdle(1000);
+      // assert
+      expect(setTimeout).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/network/NetworkIdleMonitor.ts
+++ b/src/network/NetworkIdleMonitor.ts
@@ -1,0 +1,35 @@
+import { Observer } from './Observer';
+import { NetworkRequest } from './NetworkRequest';
+import { promisify } from 'util';
+
+export class NetworkIdleMonitor {
+  private startIdleTime: number;
+
+  constructor(private readonly networkObservable: Observer<NetworkRequest>) {}
+
+  public async waitForIdle(idleTime: number) {
+    for (;;) {
+      this.startIdleTime = this.networkObservable.empty
+        ? this.startIdleTimer()
+        : undefined;
+
+      if (this.shouldResolve(idleTime)) {
+        return;
+      }
+
+      await promisify(setTimeout)(idleTime);
+    }
+  }
+
+  private startIdleTimer(): number {
+    if (!this.startIdleTime) {
+      this.startIdleTime = Date.now();
+    }
+
+    return this.startIdleTime;
+  }
+
+  private shouldResolve(idleTime: number): boolean {
+    return this.startIdleTime && Date.now() - this.startIdleTime >= idleTime;
+  }
+}

--- a/src/network/NetworkObserver.spec.ts
+++ b/src/network/NetworkObserver.spec.ts
@@ -176,6 +176,32 @@ describe('NetworkObserver', () => {
   });
 
   describe('subscribe', () => {
+    it('should return true when no pending requests', async () => {
+      // act
+      const result = sut.empty;
+      // assert
+      expect(result).toBe(true);
+    });
+
+    it('should return false when there is at least one pending request', async () => {
+      // arrange
+      when(
+        networkMock.getRequestPostData(deepEqual({ requestId: '1' }))
+      ).thenResolve({
+        postData: ''
+      });
+      when(connectionMock.subscribe(anyFunction())).thenCall(cb =>
+        cb(requestWillBeSentEvent)
+      );
+      await sut.subscribe(callback);
+      // act
+      const result = sut.empty;
+      // assert
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('subscribe', () => {
     it('should subscribe to CDP events', async () => {
       // act
       await sut.subscribe(callback);

--- a/src/network/NetworkObserver.ts
+++ b/src/network/NetworkObserver.ts
@@ -19,6 +19,10 @@ export class NetworkObserver implements Observer<NetworkRequest> {
   private destination?: (chromeEntry: NetworkRequest) => void;
   private readonly security: Security;
 
+  get empty(): boolean {
+    return this._entries.size === 0;
+  }
+
   constructor(
     private readonly options: NetworkObserverOptions,
     private readonly connection: Connection,
@@ -429,8 +433,8 @@ export class NetworkObserver implements Observer<NetworkRequest> {
 
     this.loadContent(networkRequest);
 
-    this._entries.delete(networkRequest.requestId);
     this.getExtraInfoBuilder(networkRequest.requestId).finished();
+    this._entries.delete(networkRequest.requestId);
 
     if (!this.excludeRequest(networkRequest)) {
       this.destination?.(networkRequest);

--- a/src/network/Observer.ts
+++ b/src/network/Observer.ts
@@ -1,4 +1,6 @@
 export interface Observer<T> {
+  empty: boolean;
+
   subscribe(callback: (data: T) => void): Promise<void>;
 
   unsubscribe(): Promise<void>;

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -1,6 +1,7 @@
 export { DefaultObserverFactory } from './DefaultObserverFactory';
 export { EntryBuilder } from './EntryBuilder';
 export { HarBuilder } from './HarBuilder';
+export { NetworkIdleMonitor } from './NetworkIdleMonitor';
 export { NetworkObserver } from './NetworkObserver';
 export { NetworkObserverOptions } from './NetworkObserverOptions';
 export {


### PR DESCRIPTION
You can pass the `waitForIdle` option to wait for all pending requests to complete before saving the HAR file:

```js
cy.saveHar({ waitForIdle: true });
```

This option is false by default. When set to true, the plugin will monitor the count of pending requests and wait for it to reach zero before proceeding with saving the HAR file. This ensures that all responses have been received and the data in the file is complete and accurate.

closes #147