### PR TITLE
feat(plugin): accept the `RegExp | string` union type in the patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,13 +177,13 @@ cy.recordHar({ content: false });
 To include only requests on specific hosts, you can pass an array of patterns specifying a list of hosts using the `includeHosts` for which to record requests:
 
 ```js
-cy.recordHar({ includeHosts: ['.*.execute-api.eu-west-1.amazonaws.com'] });
+cy.recordHar({ includeHosts: [/.*\.execute-api\.eu-west-1\.amazonaws\.com/] });
 ```
 
 To exclude some requests, you can pass an array of patterns specifying a list of paths using the `excludePaths` to be excluded from the logs:
 
 ```js
-cy.recordHar({ excludePaths: ['^/login', 'logout$'] });
+cy.recordHar({ excludePaths: [/^\/login/, /logout$/] });
 ```
 
 You can also pass an array of MIME types for which to record requests:

--- a/cypress/e2e/record-har.cy.ts
+++ b/cypress/e2e/record-har.cy.ts
@@ -42,7 +42,7 @@ describe('Record HAR', () => {
   );
 
   it('excludes a request by its path', () => {
-    cy.recordHar({ excludePaths: ['^\\/api\\/products$', '^\\/api\\/users$'] });
+    cy.recordHar({ excludePaths: [/^\/api\/products$/, '^\\/api\\/users$'] });
 
     cy.get('a[href$=fetch]').click();
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,17 +4,18 @@ import type { RecordOptions, SaveOptions } from './Plugin';
 Cypress.Commands.add(
   'recordHar',
   (options?: Partial<RecordOptions>): Cypress.Chainable =>
-    cy.task(
-      'recordHar',
-      Object.assign(
-        {
-          content: true,
-          includeBlobs: true,
-          rootDir: StringUtils.dirname(Cypress.spec.absolute)
-        },
-        options
+    cy.task('recordHar', {
+      content: true,
+      includeBlobs: true,
+      rootDir: StringUtils.dirname(Cypress.spec.absolute),
+      ...options,
+      excludePaths: options?.excludePaths?.map(x =>
+        StringUtils.toRegexSource(x)
+      ),
+      includeHosts: options?.includeHosts?.map(x =>
+        StringUtils.toRegexSource(x)
       )
-    )
+    })
 );
 
 Cypress.Commands.add(
@@ -23,14 +24,14 @@ Cypress.Commands.add(
     const fallbackFileName = Cypress.spec.name;
     const outDir = (Cypress.env('hars_folders') as string) ?? './';
 
-    options = Object.assign({ outDir }, options, {
+    return cy.task('saveHar', {
+      outDir,
+      ...options,
       fileName: StringUtils.normalizeName(
         options?.fileName ?? fallbackFileName,
         !options?.fileName ? { ext: '.har' } : undefined
       )
     });
-
-    return cy.task('saveHar', options);
   }
 );
 

--- a/src/network/NetworkObserverOptions.ts
+++ b/src/network/NetworkObserverOptions.ts
@@ -1,7 +1,7 @@
 export interface NetworkObserverOptions {
   content?: boolean;
-  excludePaths?: string[];
-  includeHosts?: string[];
+  excludePaths?: (string | RegExp)[];
+  includeHosts?: (string | RegExp)[];
   includeMimes?: string[];
   excludeStatusCodes?: number[];
   /**

--- a/src/network/filters/HostFilter.spec.ts
+++ b/src/network/filters/HostFilter.spec.ts
@@ -35,7 +35,7 @@ describe('HostFilter', () => {
 
     it.each([
       { includeHosts: ['example.com'] },
-      { includeHosts: ['example.com$'] },
+      { includeHosts: [/example\.com$/] },
       { includeHosts: ['example.com', 'sub.example.com'] }
     ])(
       'should return true when the filter is applicable (options: %j)',
@@ -66,7 +66,7 @@ describe('HostFilter', () => {
       // arrange
       const url = new URL('https://example.com');
       when(networkRequestMock.parsedURL).thenReturn(url);
-      const options = { includeHosts: ['example.com$'] };
+      const options = { includeHosts: [/example\.com$/] };
       // act
       const result = sut.apply(instance(networkRequestMock), options);
       // assert

--- a/src/network/filters/HostFilter.ts
+++ b/src/network/filters/HostFilter.ts
@@ -1,5 +1,6 @@
 import { NetworkRequest } from '../NetworkRequest';
 import type { RequestFilter, RequestFilterOptions } from './RequestFilter';
+import { StringUtils } from '../../utils/StringUtils';
 
 export class HostFilter implements RequestFilter {
   public apply(
@@ -8,8 +9,8 @@ export class HostFilter implements RequestFilter {
   ): boolean {
     const { host } = request.parsedURL;
 
-    return !!includeHosts?.some((pattern: string): boolean =>
-      new RegExp(pattern).test(host)
+    return !!includeHosts?.some(pattern =>
+      StringUtils.toRegex(pattern).test(host)
     );
   }
 

--- a/src/network/filters/PathFilter.spec.ts
+++ b/src/network/filters/PathFilter.spec.ts
@@ -35,7 +35,7 @@ describe('PathFilter', () => {
 
     it.each([
       { excludePaths: ['example.com'] },
-      { excludePaths: ['example.com$'] },
+      { excludePaths: [/example\.com$/] },
       { excludePaths: ['example.com', 'sub.example.com'] }
     ])(
       'should return true when the filter is applicable (options: %j)',
@@ -66,7 +66,7 @@ describe('PathFilter', () => {
       // arrange
       const url = new URL('https://example.com');
       when(networkRequestMock.parsedURL).thenReturn(url);
-      const options = { excludePaths: ['/login$'] };
+      const options = { excludePaths: [/\/login$/] };
       // act
       const result = sut.apply(instance(networkRequestMock), options);
       // assert

--- a/src/network/filters/PathFilter.ts
+++ b/src/network/filters/PathFilter.ts
@@ -1,5 +1,6 @@
 import { NetworkRequest } from '../NetworkRequest';
 import type { RequestFilter, RequestFilterOptions } from './RequestFilter';
+import { StringUtils } from '../../utils/StringUtils';
 
 export class PathFilter implements RequestFilter {
   public apply(
@@ -8,8 +9,8 @@ export class PathFilter implements RequestFilter {
   ): boolean {
     const { pathname = '/' } = request.parsedURL;
 
-    return !excludePaths?.some((pattern: string): boolean =>
-      new RegExp(pattern).test(pathname)
+    return !excludePaths?.some(pattern =>
+      StringUtils.toRegex(pattern).test(pathname)
     );
   }
 

--- a/src/utils/StringUtils.spec.ts
+++ b/src/utils/StringUtils.spec.ts
@@ -2,6 +2,58 @@ import { StringUtils } from './StringUtils';
 import { describe, expect, it } from '@jest/globals';
 
 describe('StringUtils', () => {
+  describe('isString', () => {
+    it.each([
+      { input: 'test', expected: true },
+      { input: '', expected: true },
+      { input: 0, expected: false },
+      { input: undefined, expected: false },
+      { input: null, expected: false },
+      { input: [], expected: false },
+      { input: {}, expected: false },
+      { input: Symbol.search, expected: false }
+    ])(
+      'should return $expected when value is $input',
+      ({ input, expected }) => {
+        // act
+        const result = StringUtils.isString(input);
+        // assert
+        expect(result).toBe(expected);
+      }
+    );
+  });
+
+  describe('toRegexSource', () => {
+    it.each([
+      { input: 'test', expected: 'test' },
+      { input: '', expected: '' },
+      { input: /test/, expected: 'test' },
+      { input: new RegExp(''), expected: '(?:)' }
+    ])(
+      'should return a copy of the text of the $input pattern',
+      ({ input, expected }) => {
+        // act
+        const result = StringUtils.toRegexSource(input);
+        // assert
+        expect(result).toBe(expected);
+      }
+    );
+  });
+
+  describe('toRegex', () => {
+    it.each([
+      { input: 'test' },
+      { input: '' },
+      { input: /test/ },
+      { input: new RegExp('test') }
+    ])('should return an instance of the regular expression', ({ input }) => {
+      // act
+      const result = StringUtils.toRegex(input);
+      // assert
+      expect(result).toBeInstanceOf(RegExp);
+    });
+  });
+
   describe('dirname', () => {
     it('should return the directory name of a unix path', () => {
       const path = '/path/to/file.txt';

--- a/src/utils/StringUtils.ts
+++ b/src/utils/StringUtils.ts
@@ -1,4 +1,16 @@
 export class StringUtils {
+  public static isString(value: unknown): value is string {
+    return typeof value === 'string';
+  }
+
+  public static toRegexSource(pattern: RegExp | string): string {
+    return this.isString(pattern) ? pattern : pattern.source;
+  }
+
+  public static toRegex(pattern: RegExp | string): RegExp {
+    return this.isString(pattern) ? new RegExp(pattern) : pattern;
+  }
+
   public static dirname(path: string): string {
     const normalizedPath = this.removeTrailingSlash(path);
     const fileNameIdx = this.fileNameIdx(normalizedPath);


### PR DESCRIPTION
It is now possible to utilize regular expressions rather than strings when specifying the excludePaths or includeHosts options.

**Before**:

```ts
cy.recordHar({ excludePaths: ['^\\/api\\/products$', '^\\/api\\/users$'] });
```

**After**:

```ts
cy.recordHar({ excludePaths: [/^\/api\/products$/, '^\\/api\\/users$'] });
```

closes #163