### PR TITLE
feat(plugin): allow to transform entries before saving a HAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,7 @@ export default async (entry: Entry) => {
 
 In this example, the `filter` function will only exclude entries in the HAR where the request body contains a JSON object with a password field.
 
-You can also modify the entries before saving the HAR by using the transform option. This option should be set to a path to a module that exports a function, similar to the filter option, to change the Entry object as desired.
-The function should take an Entry object as a parameter and return the modified Entry object.
+You can also modify the entries before saving the HAR by using the `transform` option. This option should be set to a path to a module that exports a function, similar to the filter option, to change the Entry object as desired.
 
 ```js
 cy.recordHar({ transform: '../support/remove-sensitive-data.ts' });
@@ -256,19 +255,18 @@ Here's a simple example of what the `remove-sensitive-data.ts` module might look
 ```ts
 import { Entry } from 'har-format';
 
-const PASSWORD_REGEXP = /"password":.*?(?=,)/g;
+const PASSWORD_REGEXP = /("password":\s*")\w+("\s*)/;
 
 export default async (entry: Entry) => {
   try {
-    // Remove sensitive information from the request and response bodies
-    entry.request.postData.text = entry.request.postData.text.replace(
-      PASSWORD_REGEXP,
-      `"password":"***"`
-    );
-    entry.response.content.text = entry.response.content.text.replace(
-      PASSWORD_REGEXP,
-      `"password":"***"`
-    );
+    // Remove sensitive information from the request body
+    if (entry.request.postData?.text) {
+      entry.request.postData.text = entry.request.postData.text.replace(
+        PASSWORD_REGEXP,
+        '$1***$2'
+      );
+    }
+
     return entry;
   } catch {
     return entry;
@@ -276,7 +274,9 @@ export default async (entry: Entry) => {
 };
 ```
 
-In this example, the transform function will replace any instances of password with `***` in both the request and response bodies of each entry.
+The function should take an Entry object as a parameter and return the modified.
+
+In this example, the transform function will replace any occurrences of password with `***` in the request body of each entry.
 
 > ✴ The plugin also supports files with `.js`, `.mjs` and `.cjs` extensions.
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,43 @@ export default async (entry: Entry) => {
 };
 ```
 
-> ✴ The plugin also supports files with `.js`, `.mjs` and `.cjs` extensions.
-
 In this example, the `filter` function will only exclude entries in the HAR where the request body contains a JSON object with a password field.
+
+You can also modify the entries before saving the HAR by using the transform option. This option should be set to a path to a module that exports a function, similar to the filter option, to change the Entry object as desired.
+The function should take an Entry object as a parameter and return the modified Entry object.
+
+```js
+cy.recordHar({ transform: '../support/remove-sensitive-data.ts' });
+```
+
+Here's a simple example of what the `remove-sensitive-data.ts` module might look like:
+
+```ts
+import { Entry } from 'har-format';
+
+const PASSWORD_REGEXP = /\"password":.*?(?=,)/g;
+
+export default async (entry: Entry) => {
+  try {
+    // Remove sensitive information from the request and response bodies
+    entry.request.postData.text = entry.request.postData.text.replace(
+      PASSWORD_REGEXP,
+      `"password": "***"`
+    );
+    entry.response.content.text = entry.response.content.text.replace(
+      PASSWORD_REGEXP,
+      `"password": "***"`
+    );
+    return entry;
+  } catch {
+    return entry;
+  }
+};
+```
+
+In this example, the transform function will replace any instances of password with `***` in both the request and response bodies of each entry.
+
+> ✴ The plugin also supports files with `.js`, `.mjs` and `.cjs` extensions.
 
 By default, the path is relative to the spec folder. But by providing a `rootDir` it will look for the module in the provided directory:
 

--- a/README.md
+++ b/README.md
@@ -256,18 +256,18 @@ Here's a simple example of what the `remove-sensitive-data.ts` module might look
 ```ts
 import { Entry } from 'har-format';
 
-const PASSWORD_REGEXP = /\"password":.*?(?=,)/g;
+const PASSWORD_REGEXP = /"password":.*?(?=,)/g;
 
 export default async (entry: Entry) => {
   try {
     // Remove sensitive information from the request and response bodies
     entry.request.postData.text = entry.request.postData.text.replace(
       PASSWORD_REGEXP,
-      `"password": "***"`
+      `"password":"***"`
     );
     entry.response.content.text = entry.response.content.text.replace(
       PASSWORD_REGEXP,
-      `"password": "***"`
+      `"password":"***"`
     );
     return entry;
   } catch {

--- a/cypress/e2e/record-har.cy.ts
+++ b/cypress/e2e/record-har.cy.ts
@@ -41,6 +41,24 @@ describe('Record HAR', () => {
     })
   );
 
+  ['.js', '.ts', '.cjs'].forEach(ext =>
+    it(`transforms a request using the custom postprocessor from ${ext} file`, () => {
+      cy.recordHar({ transform: `../fixtures/transform${ext}` });
+
+      cy.get('a[href$=fetch]').click();
+
+      cy.saveHar({ waitForIdle: true });
+
+      cy.findHar()
+        .its('log.entries')
+        .should('contain.something.like', {
+          response: {
+            content: { text: /\{"items":\[/ }
+          }
+        });
+    })
+  );
+
   it('excludes a request by its path', () => {
     cy.recordHar({ excludePaths: [/^\/api\/products$/, '^\\/api\\/users$'] });
 

--- a/cypress/fixtures/filter.cjs
+++ b/cypress/fixtures/filter.cjs
@@ -1,6 +1,6 @@
-module.exports = async req => {
+module.exports = async entry => {
   try {
-    return /\{"products":\[/.test(req.response.content.text ?? '');
+    return /\{"products":\[/.test(entry.response.content.text ?? '');
   } catch {
     return false;
   }

--- a/cypress/fixtures/filter.js
+++ b/cypress/fixtures/filter.js
@@ -1,6 +1,6 @@
-module.exports = async req => {
+module.exports = async entry => {
   try {
-    return /\{"products":\[/.test(req.response.content.text ?? '');
+    return /\{"products":\[/.test(entry.response.content.text ?? '');
   } catch {
     return false;
   }

--- a/cypress/fixtures/filter.mjs
+++ b/cypress/fixtures/filter.mjs
@@ -1,6 +1,6 @@
-export default async req => {
+export default async entry => {
   try {
-    return /\{"products":\[/.test(req.response.content.text ?? '');
+    return /\{"products":\[/.test(entry.response.content.text ?? '');
   } catch {
     return false;
   }

--- a/cypress/fixtures/filter.ts
+++ b/cypress/fixtures/filter.ts
@@ -1,8 +1,8 @@
 import { Entry } from 'har-format';
 
-export default async (req: Entry) => {
+export default async (entry: Entry) => {
   try {
-    return /\{"products":\[/.test(req.response.content.text ?? '');
+    return /\{"products":\[/.test(entry.response.content.text ?? '');
   } catch {
     return false;
   }

--- a/cypress/fixtures/transform.cjs
+++ b/cypress/fixtures/transform.cjs
@@ -1,0 +1,19 @@
+module.exports = async entry => {
+  try {
+    if (entry.response.content?.text) {
+      entry.response.content = {
+        ...entry.response.content,
+        text: entry.response.content.text.replace(
+          /"products":\s*(.+)/g,
+          `"items":$1`
+        )
+      };
+    }
+
+    return entry;
+  } catch {
+    return entry;
+  }
+};
+
+

--- a/cypress/fixtures/transform.js
+++ b/cypress/fixtures/transform.js
@@ -1,0 +1,17 @@
+module.exports = async entry => {
+  try {
+    if (entry.response.content?.text) {
+      entry.response.content = {
+        ...entry.response.content,
+        text: entry.response.content.text.replace(
+          /"products":\s*(.+)/g,
+          `"items":$1`
+        )
+      };
+    }
+
+    return entry;
+  } catch {
+    return entry;
+  }
+};

--- a/cypress/fixtures/transform.mjs
+++ b/cypress/fixtures/transform.mjs
@@ -1,0 +1,17 @@
+export async entry => {
+  try {
+    if (entry.response.content?.text) {
+      entry.response.content = {
+        ...entry.response.content,
+        text: entry.response.content.text.replace(
+          /"products":\s*(.+)/g,
+          `"items":$1`
+        )
+      };
+    }
+
+    return entry;
+  } catch {
+    return entry;
+  }
+};

--- a/cypress/fixtures/transform.ts
+++ b/cypress/fixtures/transform.ts
@@ -1,0 +1,19 @@
+import { Entry } from 'har-format';
+
+export default async (entry: Entry) => {
+  try {
+    if (entry.response.content?.text) {
+      entry.response.content = {
+        ...entry.response.content,
+        text: entry.response.content.text.replace(
+          /"products":\s*(.+)/g,
+          `"items":$1`
+        )
+      };
+    }
+
+    return entry;
+  } catch {
+    return entry;
+  }
+};

--- a/src/Plugin.spec.ts
+++ b/src/Plugin.spec.ts
@@ -1,7 +1,7 @@
 import type { RecordOptions, SaveOptions } from './Plugin';
 import { Plugin } from './Plugin';
-import { Logger } from './utils/Logger';
-import { FileManager } from './utils/FileManager';
+import type { Logger } from './utils/Logger';
+import type { FileManager } from './utils/FileManager';
 import type {
   Observer,
   ObserverFactory,

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -5,14 +5,10 @@ import type {
   HarExporterFactory,
   NetworkObserverOptions,
   Observer,
-  ObserverFactory
+  ObserverFactory,
+  HarExporterOptions
 } from './network';
-import {
-  HarBuilder,
-  HarExporterOptions,
-  NetworkIdleMonitor,
-  NetworkRequest
-} from './network';
+import { HarBuilder, NetworkIdleMonitor, NetworkRequest } from './network';
 import { ErrorUtils } from './utils/ErrorUtils';
 import type { Connection, ConnectionFactory } from './cdp';
 import {

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -28,6 +28,7 @@ export interface SaveOptions {
 export type RecordOptions = NetworkObserverOptions & {
   rootDir: string;
   filter?: string;
+  transform?: string;
 };
 
 interface Addr {
@@ -81,10 +82,7 @@ export class Plugin {
       );
     }
 
-    this.exporter = await this.exporterFactory.create({
-      predicatePath: options.filter,
-      rootDir: options.rootDir
-    });
+    this.exporter = await this.exporterFactory.create(options);
     this._connection = this.connectionFactory.create({
       ...this.addr,
       maxRetries: 20,

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -7,7 +7,12 @@ import type {
   Observer,
   ObserverFactory
 } from './network';
-import { HarBuilder, NetworkIdleMonitor, NetworkRequest } from './network';
+import {
+  HarBuilder,
+  HarExporterOptions,
+  NetworkIdleMonitor,
+  NetworkRequest
+} from './network';
 import { ErrorUtils } from './utils/ErrorUtils';
 import type { Connection, ConnectionFactory } from './cdp';
 import {
@@ -25,11 +30,7 @@ export interface SaveOptions {
   waitForIdle?: boolean;
 }
 
-export type RecordOptions = NetworkObserverOptions & {
-  rootDir: string;
-  filter?: string;
-  transform?: string;
-};
+export type RecordOptions = NetworkObserverOptions & HarExporterOptions;
 
 interface Addr {
   port: number;

--- a/src/cdp/DefaultNetwork.ts
+++ b/src/cdp/DefaultNetwork.ts
@@ -1,6 +1,6 @@
 import type { Network, NetworkEvent } from '../network';
 import { ErrorUtils } from '../utils/ErrorUtils';
-import { Logger } from '../utils/Logger';
+import type { Logger } from '../utils/Logger';
 import {
   TARGET_OR_BROWSER_CLOSED,
   UNABLE_TO_ATTACH_TO_TARGET

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const plugin = new Plugin(
   FileManager.Instance,
   new DefaultConnectionFactory(Logger.Instance),
   new DefaultObserverFactory(Logger.Instance),
-  new DefaultHarExporterFactory(FileManager.Instance)
+  new DefaultHarExporterFactory(FileManager.Instance, Logger.Instance)
 );
 
 export const install = (on: Cypress.PluginEvents): void => {

--- a/src/network/DefaultHarExporter.spec.ts
+++ b/src/network/DefaultHarExporter.spec.ts
@@ -95,7 +95,7 @@ describe('DefaultHarExporter', () => {
       // arrange
       // @ts-expect-error type mismatch
       when(streamMock.closed).thenReturn(false);
-      when(optionsSpy.predicate).thenReturn(predicate);
+      when(optionsSpy.filter).thenReturn(predicate);
       predicate.mockReturnValue(false);
 
       // act
@@ -109,7 +109,7 @@ describe('DefaultHarExporter', () => {
       // arrange
       // @ts-expect-error type mismatch
       when(streamMock.closed).thenReturn(false);
-      when(optionsSpy.predicate).thenReturn(predicate);
+      when(optionsSpy.filter).thenReturn(predicate);
       predicate.mockReturnValue(
         Promise.reject(new Error('something went wrong'))
       );
@@ -157,7 +157,7 @@ describe('DefaultHarExporter', () => {
       // arrange
       // @ts-expect-error type mismatch
       when(streamMock.closed).thenReturn(false);
-      when(optionsSpy.predicate).thenReturn(predicate);
+      when(optionsSpy.filter).thenReturn(predicate);
       predicate.mockReturnValue(true);
 
       // act
@@ -171,7 +171,7 @@ describe('DefaultHarExporter', () => {
       // arrange
       // @ts-expect-error type mismatch
       when(streamMock.closed).thenReturn(true);
-      when(optionsSpy.predicate).thenReturn(predicate);
+      when(optionsSpy.filter).thenReturn(predicate);
       predicate.mockReturnValue(false);
 
       // act

--- a/src/network/DefaultHarExporter.ts
+++ b/src/network/DefaultHarExporter.ts
@@ -1,9 +1,17 @@
 import { EntryBuilder } from './EntryBuilder';
 import type { NetworkRequest } from './NetworkRequest';
 import type { HarExporter } from './HarExporter';
+import type { Logger } from '../utils/Logger';
+import { ErrorUtils } from '../utils/ErrorUtils';
+import type {
+  DefaultHarExporterOptions,
+  Predicate,
+  Transformer
+} from './DefaultHarExporterOptions';
 import type { Entry } from 'har-format';
 import type { WriteStream } from 'fs';
 import { EOL } from 'os';
+import { format } from 'util';
 
 export class DefaultHarExporter implements HarExporter {
   get path(): string {
@@ -12,9 +20,18 @@ export class DefaultHarExporter implements HarExporter {
     return Buffer.isBuffer(path) ? path.toString('utf-8') : path;
   }
 
+  private get predicate(): Predicate | undefined {
+    return this.options?.predicate;
+  }
+
+  private get transform(): Transformer | undefined {
+    return this.options?.transform;
+  }
+
   constructor(
+    private readonly logger: Logger,
     private readonly buffer: WriteStream,
-    private readonly predicate?: (entry: Entry) => Promise<unknown> | unknown
+    private readonly options?: DefaultHarExporterOptions
   ) {}
 
   public async write(networkRequest: NetworkRequest): Promise<void> {
@@ -24,11 +41,37 @@ export class DefaultHarExporter implements HarExporter {
       return;
     }
 
-    const json = JSON.stringify(entry);
+    const json = await this.serializeEntry(entry);
 
     // @ts-expect-error type mismatch
-    if (!this.buffer.closed) {
+    if (!this.buffer.closed && json) {
       this.buffer.write(`${json}${EOL}`);
+    }
+  }
+
+  public async serializeEntry(entry: Entry): Promise<string | undefined> {
+    try {
+      const result =
+        typeof this.transform === 'function'
+          ? await this.transform(entry)
+          : entry;
+
+      return JSON.stringify(result);
+    } catch (e) {
+      const stack = ErrorUtils.isError(e) ? e.stack : e;
+      const formattedEntry = format('%j', entry);
+
+      this.logger.err(
+        `The entry is missing as a result of an error in the 'transform' function.
+
+The passed entry:
+${formattedEntry}
+
+The stack trace for this error is: 
+${stack}`
+      );
+
+      return undefined;
     }
   }
 
@@ -36,12 +79,18 @@ export class DefaultHarExporter implements HarExporter {
     this.buffer.end();
   }
 
-  private async applyPredicate(entry: Entry) {
+  private async applyPredicate(entry: Entry): Promise<unknown> {
     try {
       return (
         typeof this.predicate === 'function' && (await this.predicate?.(entry))
       );
-    } catch {
+    } catch (e) {
+      const message = ErrorUtils.isError(e) ? e.message : e;
+
+      this.logger.debug(
+        `The operation has encountered an error while processing the entry. ${message}`
+      );
+
       return false;
     }
   }

--- a/src/network/DefaultHarExporter.ts
+++ b/src/network/DefaultHarExporter.ts
@@ -5,7 +5,7 @@ import type { Logger } from '../utils/Logger';
 import { ErrorUtils } from '../utils/ErrorUtils';
 import type {
   DefaultHarExporterOptions,
-  Predicate,
+  Filter,
   Transformer
 } from './DefaultHarExporterOptions';
 import type { Entry } from 'har-format';
@@ -20,8 +20,8 @@ export class DefaultHarExporter implements HarExporter {
     return Buffer.isBuffer(path) ? path.toString('utf-8') : path;
   }
 
-  private get predicate(): Predicate | undefined {
-    return this.options?.predicate;
+  private get filter(): Filter | undefined {
+    return this.options?.filter;
   }
 
   private get transform(): Transformer | undefined {
@@ -37,7 +37,7 @@ export class DefaultHarExporter implements HarExporter {
   public async write(networkRequest: NetworkRequest): Promise<void> {
     const entry = await new EntryBuilder(networkRequest).build();
 
-    if (await this.applyPredicate(entry)) {
+    if (await this.applyFilter(entry)) {
       return;
     }
 
@@ -79,11 +79,9 @@ ${stack}`
     this.buffer.end();
   }
 
-  private async applyPredicate(entry: Entry): Promise<unknown> {
+  private async applyFilter(entry: Entry): Promise<unknown> {
     try {
-      return (
-        typeof this.predicate === 'function' && (await this.predicate?.(entry))
-      );
+      return typeof this.filter === 'function' && (await this.filter(entry));
     } catch (e) {
       const message = ErrorUtils.isError(e) ? e.message : e;
 

--- a/src/network/DefaultHarExporter.ts
+++ b/src/network/DefaultHarExporter.ts
@@ -59,14 +59,13 @@ export class DefaultHarExporter implements HarExporter {
       return JSON.stringify(result);
     } catch (e) {
       const stack = ErrorUtils.isError(e) ? e.stack : e;
-      const formattedEntry = format('%j', entry);
 
+      this.logger.debug(
+        format(`The entry has been filtered out due to an error: %j`, entry)
+      );
       this.logger.err(
         `The entry is missing as a result of an error in the 'transform' function.
-
-The passed entry:
-${formattedEntry}
-
+s
 The stack trace for this error is: 
 ${stack}`
       );

--- a/src/network/DefaultHarExporterFactory.spec.ts
+++ b/src/network/DefaultHarExporterFactory.spec.ts
@@ -62,8 +62,8 @@ describe('DefaultHarExporterFactory', () => {
       // arrange
       const options = {
         rootDir: '/root',
-        predicatePath: 'predicate.js',
-        transformPath: 'transform.js'
+        filter: 'predicate.js',
+        transform: 'transform.js'
       };
       when(fileManagerMock.createTmpWriteStream()).thenResolve(
         resolvableInstance(writeStreamMock)
@@ -77,6 +77,7 @@ describe('DefaultHarExporterFactory', () => {
       // assert
       expect(result).toBeInstanceOf(DefaultHarExporter);
       verify(loaderSpy.load('/root/predicate.js')).once();
+      verify(loaderSpy.load('/root/transform.js')).once();
     });
 
     it('should create a HarExporter instance without pre and post processors', async () => {

--- a/src/network/DefaultHarExporterFactory.spec.ts
+++ b/src/network/DefaultHarExporterFactory.spec.ts
@@ -2,6 +2,7 @@ import type { FileManager } from '../utils/FileManager';
 import { DefaultHarExporterFactory } from './DefaultHarExporterFactory';
 import { DefaultHarExporter } from './DefaultHarExporter';
 import { Loader } from '../utils/Loader';
+import type { Logger } from '../utils/Logger';
 import { instance, mock, reset, spy, verify, when } from 'ts-mockito';
 import {
   jest,
@@ -31,31 +32,44 @@ const resolvableInstance = <T extends object>(m: T): T =>
 describe('DefaultHarExporterFactory', () => {
   const fileManagerMock = mock<FileManager>();
   const writeStreamMock = mock<WriteStream>();
+  const loggerMock = mock<Logger>();
   const loaderSpy = spy(Loader);
   const predicate = jest.fn();
+  const transform = jest.fn();
 
   let factory!: DefaultHarExporterFactory;
 
   beforeEach(() => {
-    factory = new DefaultHarExporterFactory(instance(fileManagerMock));
+    factory = new DefaultHarExporterFactory(
+      instance(fileManagerMock),
+      instance(loggerMock)
+    );
   });
 
-  afterEach(() =>
-    reset<FileManager | WriteStream | typeof Loader>(
+  afterEach(() => {
+    transform.mockReset();
+    predicate.mockReset();
+    reset<FileManager | WriteStream | Logger | typeof Loader>(
       fileManagerMock,
       writeStreamMock,
-      loaderSpy
-    )
-  );
+      loaderSpy,
+      loggerMock
+    );
+  });
 
   describe('create', () => {
     it('should create a HarExporter instance', async () => {
       // arrange
-      const options = { rootDir: '/root', predicatePath: 'predicate.js' };
+      const options = {
+        rootDir: '/root',
+        predicatePath: 'predicate.js',
+        transformPath: 'transform.js'
+      };
       when(fileManagerMock.createTmpWriteStream()).thenResolve(
         resolvableInstance(writeStreamMock)
       );
       when(loaderSpy.load('/root/predicate.js')).thenResolve(predicate);
+      when(loaderSpy.load('/root/transform.js')).thenResolve(transform);
 
       // act
       const result = await factory.create(options);
@@ -65,7 +79,7 @@ describe('DefaultHarExporterFactory', () => {
       verify(loaderSpy.load('/root/predicate.js')).once();
     });
 
-    it('should create a HarExporter instance without predicate', async () => {
+    it('should create a HarExporter instance without pre and post processors', async () => {
       // arrange
       const options = { rootDir: '/root' };
       when(fileManagerMock.createTmpWriteStream()).thenResolve(

--- a/src/network/DefaultHarExporterFactory.ts
+++ b/src/network/DefaultHarExporterFactory.ts
@@ -5,27 +5,54 @@ import type {
 import type { HarExporter } from './HarExporter';
 import { DefaultHarExporter } from './DefaultHarExporter';
 import { Loader } from '../utils/Loader';
-import { FileManager } from '../utils/FileManager';
-import type { Entry } from 'har-format';
+import type { FileManager } from '../utils/FileManager';
+import type { Logger } from '../utils/Logger';
+import type {
+  DefaultHarExporterOptions,
+  Predicate,
+  Transformer
+} from './DefaultHarExporterOptions';
 import { resolve } from 'path';
 
 export class DefaultHarExporterFactory implements HarExporterFactory {
-  constructor(private readonly fileManager: FileManager) {}
+  constructor(
+    private readonly fileManager: FileManager,
+    private readonly logger: Logger
+  ) {}
 
-  public async create({
-    rootDir,
-    predicatePath
-  }: HarExporterOptions): Promise<HarExporter> {
-    let predicate: ((request: Entry) => unknown) | undefined;
+  public async create(options: HarExporterOptions): Promise<HarExporter> {
+    const settings = await this.createSettings(options);
+    const stream = await this.fileManager.createTmpWriteStream();
 
-    if (predicatePath) {
-      const absolutePath = resolve(rootDir, predicatePath);
-      predicate = await Loader.load(absolutePath);
+    return new DefaultHarExporter(this.logger, stream, settings);
+  }
+
+  private async createSettings({
+    predicatePath,
+    transformPath,
+    rootDir
+  }: HarExporterOptions) {
+    const [predicate, transform]: (Predicate | Transformer | undefined)[] =
+      await Promise.all(
+        [predicatePath, transformPath].map(path =>
+          this.loadCustomProcessor(path, rootDir)
+        )
+      );
+
+    return { predicate, transform } as DefaultHarExporterOptions;
+  }
+
+  private async loadCustomProcessor<T extends Predicate | Transformer>(
+    path: string | undefined,
+    rootDir: string
+  ): Promise<T | undefined> {
+    let processor: T | undefined;
+
+    if (path) {
+      const absolutePath = resolve(rootDir, path);
+      processor = await Loader.load(absolutePath);
     }
 
-    return new DefaultHarExporter(
-      await this.fileManager.createTmpWriteStream(),
-      predicate
-    );
+    return processor;
   }
 }

--- a/src/network/DefaultHarExporterFactory.ts
+++ b/src/network/DefaultHarExporterFactory.ts
@@ -9,7 +9,7 @@ import type { FileManager } from '../utils/FileManager';
 import type { Logger } from '../utils/Logger';
 import type {
   DefaultHarExporterOptions,
-  Predicate,
+  Filter,
   Transformer
 } from './DefaultHarExporterOptions';
 import { resolve } from 'path';
@@ -28,21 +28,22 @@ export class DefaultHarExporterFactory implements HarExporterFactory {
   }
 
   private async createSettings({
-    predicatePath,
-    transformPath,
+    filter,
+    transform,
     rootDir
   }: HarExporterOptions) {
-    const [predicate, transform]: (Predicate | Transformer | undefined)[] =
+    const [preProcessor, postProcessor]: (Filter | Transformer | undefined)[] =
       await Promise.all(
-        [predicatePath, transformPath].map(path =>
-          this.loadCustomProcessor(path, rootDir)
-        )
+        [filter, transform].map(path => this.loadCustomProcessor(path, rootDir))
       );
 
-    return { predicate, transform } as DefaultHarExporterOptions;
+    return {
+      filter: preProcessor,
+      transform: postProcessor
+    } as DefaultHarExporterOptions;
   }
 
-  private async loadCustomProcessor<T extends Predicate | Transformer>(
+  private async loadCustomProcessor<T extends Filter | Transformer>(
     path: string | undefined,
     rootDir: string
   ): Promise<T | undefined> {

--- a/src/network/DefaultHarExporterOptions.ts
+++ b/src/network/DefaultHarExporterOptions.ts
@@ -1,9 +1,9 @@
 import type { Entry } from 'har-format';
 
-export type Predicate = (entry: Entry) => Promise<unknown> | unknown;
+export type Filter = (entry: Entry) => Promise<unknown> | unknown;
 export type Transformer = (entry: Entry) => Promise<Entry> | Entry;
 
 export interface DefaultHarExporterOptions {
-  predicate?: Predicate;
+  filter?: Filter;
   transform?: Transformer;
 }

--- a/src/network/DefaultHarExporterOptions.ts
+++ b/src/network/DefaultHarExporterOptions.ts
@@ -1,0 +1,9 @@
+import type { Entry } from 'har-format';
+
+export type Predicate = (entry: Entry) => Promise<unknown> | unknown;
+export type Transformer = (entry: Entry) => Promise<Entry> | Entry;
+
+export interface DefaultHarExporterOptions {
+  predicate?: Predicate;
+  transform?: Transformer;
+}

--- a/src/network/HarExporterFactory.ts
+++ b/src/network/HarExporterFactory.ts
@@ -2,8 +2,8 @@ import type { HarExporter } from './HarExporter';
 
 export interface HarExporterOptions {
   rootDir: string;
-  predicatePath?: string;
-  transformPath?: string;
+  filter?: string;
+  transform?: string;
 }
 
 export interface HarExporterFactory {

--- a/src/network/HarExporterFactory.ts
+++ b/src/network/HarExporterFactory.ts
@@ -3,6 +3,7 @@ import type { HarExporter } from './HarExporter';
 export interface HarExporterOptions {
   rootDir: string;
   predicatePath?: string;
+  transformPath?: string;
 }
 
 export interface HarExporterFactory {

--- a/src/network/index.ts
+++ b/src/network/index.ts
@@ -21,3 +21,4 @@ export { HarBuilder } from './HarBuilder';
 export { NetworkIdleMonitor } from './NetworkIdleMonitor';
 export { NetworkObserver } from './NetworkObserver';
 export { NetworkRequest, WebSocketFrameType } from './NetworkRequest';
+export type { DefaultHarExporterOptions } from './DefaultHarExporterOptions';


### PR DESCRIPTION
You can modify the entries before saving the HAR by using the `transform` option. This option should be set to a path to a module that exports a function, similar to the filter option, to change the Entry object as desired.

```js
cy.recordHar({ transform: '../support/remove-sensitive-data.ts' });
```

Here's a simple example of what the `remove-sensitive-data.ts` module might look like:

```ts
import { Entry } from 'har-format';

const PASSWORD_REGEXP = /("password":\s*")\w+("\s*)/;

export default async (entry: Entry) => {
  try {
    // Remove sensitive information from the request body
    if (entry.request.postData?.text) {
      entry.request.postData.text = entry.request.postData.text.replace(
        PASSWORD_REGEXP,
        '$1***$2'
      );
    }

    return entry;
  } catch {
    return entry;
  }
};
```


In this example, the transform function will replace any instances of password with `***` in both the request and response bodies of each entry.


closes #174