### PR TITLE
feat(plugin): make plugin a "no-op" in unsupported browsers

### DIFF
--- a/src/Plugin.spec.ts
+++ b/src/Plugin.spec.ts
@@ -236,6 +236,8 @@ describe('Plugin', () => {
     } as SaveOptions;
 
     it('should log an error message when the connection is corrupted', async () => {
+      // arrange
+      plugin.ensureBrowserFlags(chrome, []);
       // act
       await plugin.saveHar(options);
       // assert

--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -77,13 +77,13 @@ export class Plugin {
   }
 
   public async recordHar(options: RecordOptions): Promise<void> {
-    await this.closeConnection();
-
     if (!this.addr) {
       throw new Error(
         `Please call the 'ensureBrowserFlags' before attempting to start the recording.`
       );
     }
+
+    await this.closeConnection();
 
     this.exporter = await this.exporterFactory.create(options);
     this._connection = this.connectionFactory.create({


### PR DESCRIPTION
Addresses https://github.com/NeuraLegion/cypress-har-generator/issues/5#issuecomment-1987030824

Previously the plugin would throw an error when it was running in an unsupported browser. This was not great for plugin consumers who run their cypress tests in both supported and unsupported browsers and are fine with only having HAR recording in supported browsers: It forced them to conditionally enable this plugin.

To address this, we're changing the plugin to do nothing except `warn` that HAR recording is not supported when running in an unsupported browser.