### PR TITLE
Update usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,15 @@ To generate a HAR file, you'll need to include the following code in your test f
 describe('my tests', () => {
   before(() => {
     // start recording
-    cy.recordHar();
+    cy.task('recordHar', {});
   });
 
   after(() => {
     // save the HAR file
-    cy.saveHar();
+    cy.task('saveHar', {
+      outDir: '.',
+      fileName: 'my.har',
+    });
   });
 });
 ```


### PR DESCRIPTION
As mentioned in https://github.com/NeuraLegion/cypress-har-generator/issues/396#issuecomment-2890349598

This is the only option that worked on Cypress v13.15.1 and cypress-har-generator v5.17.1:

```js
cy.task('recordHar', {});
...
cy.task('saveHar', {
  outDir: '.',
  fileName: 'my.har',
});
```